### PR TITLE
SerializerOptions: add setShiftSize

### DIFF
--- a/include/json_struct.h
+++ b/include/json_struct.h
@@ -666,6 +666,7 @@ public:
   SerializerOptions(Style style = Style::Pretty);
 
   int shiftSize() const;
+  void setShiftSize(unsigned char set);
 
   Style style() const;
   void setStyle(Style style);
@@ -1757,6 +1758,11 @@ inline SerializerOptions::SerializerOptions(Style style)
 inline int SerializerOptions::shiftSize() const
 {
   return m_shift_size;
+}
+
+inline void SerializerOptions::setShiftSize(unsigned char set)
+{
+  m_shift_size = set;
 }
 
 inline unsigned char SerializerOptions::depth() const


### PR DESCRIPTION
Added functionality for user to change shiftSize in SerializerOptions.
Example: 2 spaces instead of 4 with Pretty Style.

Example:
```
JS::SerializerOptions ops(JS::SerializerOptions::Pretty);
ops.setShiftSize(2);
```