### PR TITLE
Added user data member to ParseContext

### DIFF
--- a/include/json_struct.h
+++ b/include/json_struct.h
@@ -2662,6 +2662,16 @@ struct ParseContext
   template <typename T>
   Error parseTo(T &to_type);
 
+  void* getUserData() const
+  {
+    return user_data;
+  }
+
+  void setUserData(void* data)
+  {
+    user_data = data;
+  }
+
   Error nextToken()
   {
     error = tokenizer.nextToken(token);
@@ -2720,6 +2730,7 @@ struct ParseContext
   bool allow_missing_members = true;
   bool allow_unnasigned_required_members = true;
   bool track_member_assignement_state = true;
+  void* user_data = nullptr;
 };
 
 /*! \def JS_MEMBER
@@ -3757,7 +3768,7 @@ struct JsonStructFunctionContainerDummy
   }
 
 #define JS_FUNC_OBJ(...) JS_FUNCTION_CONTAINER_INTERNAL_IMPL(JS::makeTuple(), JS::makeTuple(JS_INTERNAL_MAKE_FUNCTIONS(__VA_ARGS__)))
-#define JS_FUNCTION_CONTAINER(...) JS_FUNCTION_CONTAINER_INTERNAL_IMPL(JS::makeTuple(), JS::makeTuple(__VA_ARGS__)) 
+#define JS_FUNCTION_CONTAINER(...) JS_FUNCTION_CONTAINER_INTERNAL_IMPL(JS::makeTuple(), JS::makeTuple(__VA_ARGS__))
 #define JS_FUNC_OBJ_SUPER(super_list, ...)  JS_FUNCTION_CONTAINER_INTERNAL_IMPL(super_list, JS::makeTuple(JS_INTERNAL_MAKE_FUNCTIONS(__VA_ARGS__)))
 #define JS_FUNCTION_CONTAINER_WITH_SUPER(super_list, ...) JS_FUNCTION_CONTAINER_INTERNAL_IMPL(super_list, JS::makeTuple(__VA_ARGS__))
 

--- a/include/json_struct.h
+++ b/include/json_struct.h
@@ -2662,16 +2662,6 @@ struct ParseContext
   template <typename T>
   Error parseTo(T &to_type);
 
-  void* getUserData() const
-  {
-    return user_data;
-  }
-
-  void setUserData(void* data)
-  {
-    user_data = data;
-  }
-
   Error nextToken()
   {
     error = tokenizer.nextToken(token);


### PR DESCRIPTION
For my particular use case, I have to use `const char*` members in my structs instead of `std::string`. To accomplish this, I have to keep the parsed strings somewhere in memory and use a custom type handler to provide the `const char*` pointer to the output struct.

I realised this process would be made at least a little safer if the `ParseContext` class had support for some user data, since then my string memory pools could be provided on a per-parse basis rather than needing to be static global pools. I've created this PR simply to add a `void*` member to the `ParseContext` for this purpose. This should allow anyone else to provide context-specific data for when they do their own parsing.