### PR TITLE
Resolved warnings on MSVC

### DIFF
--- a/include/json_struct/json_struct.h
+++ b/include/json_struct/json_struct.h
@@ -156,7 +156,7 @@
 #if __cpp_if_constexpr
 #define JS_IF_CONSTEXPR(exp) if constexpr (exp)
 #elif defined(_MSC_VER)
-#define JS_IF_CONSTEXPR(exp) if (([]() -> bool { return (exp); })())
+#define JS_IF_CONSTEXPR(exp) __pragma(warning(push)) __pragma(warning(disable : 4127)) if (exp) __pragma(warning(pop))
 #else
 #define JS_IF_CONSTEXPR(exp) if (exp)
 #endif


### PR DESCRIPTION
This PR fixes a couple of warnings I came across:

* There was an `if` statement missing a constexpr qualification on one of the conditions. Since the condition was compound, with one bit being constexpr and the other not, I separated it into two.
* In certain cases, one of the template functions could trigger warnings about downcasting to integers of a different size, so I added an explicit cast to remove these warnings.