### PR TITLE
Recoded `tests/json-struct-float.cpp` into UTF-8.

### DIFF
--- a/tests/json-struct-float.cpp
+++ b/tests/json-struct-float.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Jorgen Lind
+ * Copyright Â© 2021 Jorgen Lind
  *
  * Permission to use, copy, modify, distribute, and sell this software and its
  * documentation for any purpose is hereby granted without fee, provided that


### PR DESCRIPTION
This fixes `../tests/json-struct-float.cpp:2:14: error: invalid UTF-8 in comment [-Werror,-Winvalid-utf8]` when compiling with Clang.