### PR TITLE
new macros for enum value parsing

### DIFF
--- a/include/json_struct/json_struct.h
+++ b/include/json_struct/json_struct.h
@@ -4524,6 +4524,88 @@ void populateEnumNames(std::vector<DataRef> &names, const char (&data)[N])
   };                                                                                                                   \
   }
 
+#define JS_ENUM_DECLARE_VALUE_PARSER(name)                                                                             \
+  namespace JS                                                                                                         \
+  {                                                                                                                    \
+  template <>                                                                                                          \
+  struct TypeHandler<name>                                                                                             \
+  {                                                                                                                    \
+    static inline Error to(name &to_type, ParseContext &context)                                                       \
+    {                                                                                                                  \
+      if (std::is_unsigned<name>::value)                                                                               \
+      {                                                                                                                \
+        unsigned int to_value;                                                                                         \
+        JS::Error result = TypeHandler<unsigned int>::to(to_value, context);                                           \
+        if (result == JS::Error::NoError)                                                                              \
+          to_type = static_cast<name>(to_value);                                                                       \
+        return result;                                                                                                 \
+      }                                                                                                                \
+      else                                                                                                             \
+      {                                                                                                                \
+        int to_value;                                                                                                  \
+        JS::Error result = TypeHandler<int>::to(to_value, context);                                                    \
+        if (result == JS::Error::NoError)                                                                              \
+          to_type = static_cast<name>(to_value);                                                                       \
+        return result;                                                                                                 \
+      }                                                                                                                \
+    }                                                                                                                  \
+    static inline void from(const name &from_type, Token &token, Serializer &serializer)                               \
+    {                                                                                                                  \
+      if (std::is_unsigned<name>::value)                                                                               \
+      {                                                                                                                \
+        const unsigned int from_value = static_cast<uint64_t>(from_type);                                              \
+        TypeHandler<uint64_t>::from(from_value, token, serializer);                                                    \
+      }                                                                                                                \
+      else                                                                                                             \
+      {                                                                                                                \
+        const int from_value = static_cast<int>(from_type);                                                            \
+        TypeHandler<int64_t>::from(from_value, token, serializer);                                                     \
+      }                                                                                                                \
+    }                                                                                                                  \
+  };                                                                                                                   \
+  }
+
+#define JS_ENUM_NAMESPACE_DECLARE_VALUE_PARSER(ns, name)                                                               \
+  namespace JS                                                                                                         \
+  {                                                                                                                    \
+  template <>                                                                                                          \
+  struct TypeHandler<ns::name>                                                                                         \
+  {                                                                                                                    \
+    static inline Error to(ns::name &to_type, ParseContext &context)                                                   \
+    {                                                                                                                  \
+      if (std::is_unsigned<ns::name>::value)                                                                           \
+      {                                                                                                                \
+        unsigned int to_value;                                                                                         \
+        JS::Error result = TypeHandler<unsigned int>::to(to_value, context);                                           \
+        if (result == JS::Error::NoError)                                                                              \
+          to_type = static_cast<ns::name>(to_value);                                                                   \
+        return result;                                                                                                 \
+      }                                                                                                                \
+      else                                                                                                             \
+      {                                                                                                                \
+        int to_value;                                                                                                  \
+        JS::Error result = TypeHandler<int>::to(to_value, context);                                                    \
+        if (result == JS::Error::NoError)                                                                              \
+          to_type = static_cast<ns::name>(to_value);                                                                   \
+        return result;                                                                                                 \
+      }                                                                                                                \
+    }                                                                                                                  \
+    static inline void from(const ns::name &from_type, Token &token, Serializer &serializer)                           \
+    {                                                                                                                  \
+      if (std::is_unsigned<ns::name>::value)                                                                           \
+      {                                                                                                                \
+        const unsigned int from_value = static_cast<uint64_t>(from_type);                                              \
+        TypeHandler<uint64_t>::from(from_value, token, serializer);                                                    \
+      }                                                                                                                \
+      else                                                                                                             \
+      {                                                                                                                \
+        const int from_value = static_cast<int>(from_type);                                                            \
+        TypeHandler<int64_t>::from(from_value, token, serializer);                                                     \
+      }                                                                                                                \
+    }                                                                                                                  \
+  };                                                                                                                   \
+  }
+
 namespace JS
 {
 template <typename T, typename Enable>

--- a/include/json_struct/json_struct.h
+++ b/include/json_struct/json_struct.h
@@ -4530,37 +4530,19 @@ void populateEnumNames(std::vector<DataRef> &names, const char (&data)[N])
   template <>                                                                                                          \
   struct TypeHandler<name>                                                                                             \
   {                                                                                                                    \
+    typedef std::underlying_type<name>::type utype;                                                                    \
     static inline Error to(name &to_type, ParseContext &context)                                                       \
     {                                                                                                                  \
-      if (std::is_unsigned<name>::value)                                                                               \
-      {                                                                                                                \
-        unsigned int to_value;                                                                                         \
-        JS::Error result = TypeHandler<unsigned int>::to(to_value, context);                                           \
-        if (result == JS::Error::NoError)                                                                              \
-          to_type = static_cast<name>(to_value);                                                                       \
-        return result;                                                                                                 \
-      }                                                                                                                \
-      else                                                                                                             \
-      {                                                                                                                \
-        int to_value;                                                                                                  \
-        JS::Error result = TypeHandler<int>::to(to_value, context);                                                    \
-        if (result == JS::Error::NoError)                                                                              \
-          to_type = static_cast<name>(to_value);                                                                       \
-        return result;                                                                                                 \
-      }                                                                                                                \
+      utype to_value;                                                                                                  \
+      JS::Error result = TypeHandler<utype>::to(to_value, context);                                                    \
+      if (result == JS::Error::NoError)                                                                                \
+        to_type = static_cast<name>(to_value);                                                                         \
+      return result;                                                                                                   \
     }                                                                                                                  \
     static inline void from(const name &from_type, Token &token, Serializer &serializer)                               \
     {                                                                                                                  \
-      if (std::is_unsigned<name>::value)                                                                               \
-      {                                                                                                                \
-        const unsigned int from_value = static_cast<uint64_t>(from_type);                                              \
-        TypeHandler<uint64_t>::from(from_value, token, serializer);                                                    \
-      }                                                                                                                \
-      else                                                                                                             \
-      {                                                                                                                \
-        const int from_value = static_cast<int>(from_type);                                                            \
-        TypeHandler<int64_t>::from(from_value, token, serializer);                                                     \
-      }                                                                                                                \
+        const utype from_value = static_cast<utype>(from_type);                                                        \
+        TypeHandler<utype>::from(from_value, token, serializer);                                                       \
     }                                                                                                                  \
   };                                                                                                                   \
   }
@@ -4571,37 +4553,19 @@ void populateEnumNames(std::vector<DataRef> &names, const char (&data)[N])
   template <>                                                                                                          \
   struct TypeHandler<ns::name>                                                                                         \
   {                                                                                                                    \
+    typedef std::underlying_type<ns::name>::type utype;                                                                \
     static inline Error to(ns::name &to_type, ParseContext &context)                                                   \
     {                                                                                                                  \
-      if (std::is_unsigned<ns::name>::value)                                                                           \
-      {                                                                                                                \
-        unsigned int to_value;                                                                                         \
-        JS::Error result = TypeHandler<unsigned int>::to(to_value, context);                                           \
-        if (result == JS::Error::NoError)                                                                              \
-          to_type = static_cast<ns::name>(to_value);                                                                   \
-        return result;                                                                                                 \
-      }                                                                                                                \
-      else                                                                                                             \
-      {                                                                                                                \
-        int to_value;                                                                                                  \
-        JS::Error result = TypeHandler<int>::to(to_value, context);                                                    \
-        if (result == JS::Error::NoError)                                                                              \
-          to_type = static_cast<ns::name>(to_value);                                                                   \
-        return result;                                                                                                 \
-      }                                                                                                                \
+      utype to_value;                                                                                                  \
+      JS::Error result = TypeHandler<utype>::to(to_value, context);                                                    \
+      if (result == JS::Error::NoError)                                                                                \
+        to_type = static_cast<ns::name>(to_value);                                                                     \
+      return result;                                                                                                   \
     }                                                                                                                  \
     static inline void from(const ns::name &from_type, Token &token, Serializer &serializer)                           \
     {                                                                                                                  \
-      if (std::is_unsigned<ns::name>::value)                                                                           \
-      {                                                                                                                \
-        const unsigned int from_value = static_cast<uint64_t>(from_type);                                              \
-        TypeHandler<uint64_t>::from(from_value, token, serializer);                                                    \
-      }                                                                                                                \
-      else                                                                                                             \
-      {                                                                                                                \
-        const int from_value = static_cast<int>(from_type);                                                            \
-        TypeHandler<int64_t>::from(from_value, token, serializer);                                                     \
-      }                                                                                                                \
+        const utype from_value = static_cast<utype>(from_type);                                                        \
+        TypeHandler<utype>::from(from_value, token, serializer);                                                       \
     }                                                                                                                  \
   };                                                                                                                   \
   }


### PR DESCRIPTION
Added two new macros for enums: JS_ENUM_DECLARE_VALUE_PARSER and JS_ENUM_NAMESPACE_DECLARE_VALUE_PARSER. These work like the existing enum parser macros. They define type handlers for an enum, but instead of using the name of the enumeration, the underlying value is read and written as an integer.

This was developed as an alternative to generalizing JS_ENUM to handle enumeration declarations with initializers.