### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/json_struct
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/json_struct

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,4 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+        

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+# Copy fuzzer executables to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/json_struct/.clusterfuzzlite/reformat_fuzzer.cpp \
+  -o $OUT/reformat_fuzzer \
+  -I$SRC/json_struct/include

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.clusterfuzzlite/reformat_fuzzer.cpp
+++ b/.clusterfuzzlite/reformat_fuzzer.cpp
@@ -1,0 +1,10 @@
+#include <json_struct/json_struct.h>
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  std::string pretty;
+  JS::reformat((const char *)data, size, pretty);
+
+  return 0;
+}

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,7 @@ name: ClusterFuzzLite PR fuzzing
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 permissions: read-all
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `reformat`, and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

To reproduce this set up the way ClusterFuzzLite does it (by way of [OSS-Fuzz](https://github.com/google/oss)) you can do:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/json_struct
cd json_struct
git checkout clusterfuzzlite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD reformat_fuzzer-- -max_total_time=10
```

I think if you'd be happy to have this merged, then it would also make sense to adjust some of the `assert`s in the code to throw exceptions, since the fuzzer would be able to run for longer periods of time without interruption (the asserts cause the fuzzer to stop). There is a macro `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` which is enabled by default when compiling for fuzzing, so one option would be to add these macros around around the `asserts` to enforce such that the `asserts` are exceptions in fuzz mode, and then having the fuzzers catch these.