### PR TITLE
Add conanfile and test_package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ tests/json-tokenizer-partial-test
 tests/json-tree-test
 tests/json-tree-printer-test
 
+*CMakeUserPresets.json
+build/

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,67 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.scm import Git, Version
+from conan.tools.files import copy
+
+import os
+
+class JsonStructLibrary(ConanFile):
+    name = "json_struct"
+
+    # Metadata
+    license = "MIT"
+    version = "1.0.0"
+    author = "Jørgen Lind <jorgen.lind@gmail.com>"
+    url = "https://github.com/jorgen/json_struct"
+    description = "json_struct is a single header only C++ library for parsing JSON directly to C++ structs and vice versa"
+
+    topics = ("serialization", "deserialization", "reflection", "json")
+
+    settings = "os", "compiler", "build_type", "arch"
+    pacgake_type = "header-library"
+    implements = ["auto_header_only"]
+    exports_sources = "include/*", "cmake/*" "CMakeLists.txt"
+
+    options = {
+        "opt_build_benchmarks": [True, False],
+        "opt_build_examples": [True, False],
+        "opt_build_tests": [True, False],
+        "opt_disable_pch": [True, False],
+        "opt_install": [True, False],
+    }
+
+    default_options = {
+        "opt_build_benchmarks": False,
+        "opt_build_examples": False,
+        "opt_build_tests": False,
+        "opt_disable_pch": False,
+        "opt_install": True,
+    }
+
+    def generate(self):
+        toolchain = CMakeToolchain(self)
+
+        toolchain.variables["JSON_STRUCT_OPT_BUILD_BENCHMARKS"] = self.options.opt_build_benchmarks.value
+        toolchain.variables["JSON_STRUCT_OPT_BUILD_EXAMPLES"] = self.options.opt_build_examples.value
+        toolchain.variables["JSON_STRUCT_OPT_BUILD_TESTS"] = self.options.opt_build_tests.value
+        toolchain.variables["JSON_STRUCT_OPT_DISABLE_PCH"] = self.options.opt_disable_pch.value
+        toolchain.variables["JSON_STRUCT_OPT_INSTALL"] = self.options.opt_install
+
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        # Invoke cmake --install
+        cmake = CMake(self)
+        cmake.install()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def package_id(self):
+        self.info.clear()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(JsonStructTester
+        DESCRIPTION "Tester package for json_struct"
+        LANGUAGES C CXX)
+
+find_package(json_struct REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} json_struct::json_struct)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,28 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class JsonStructTest(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            self.output.info("Checking compiled tester...")
+            cmd = os.path.join(self.cpp.build.bindir, "JsonStructTester")
+            self.run(cmd, env="conanrun")
+

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -1,0 +1,19 @@
+#include "json_struct/json_struct.h"
+#include <iostream>
+
+struct MyTestStruct
+{
+    std::string name;
+    unsigned age;
+    JS_OBJ(name, age);
+};
+
+int main()
+{
+    MyTestStruct person{.name="Jonh", .age=23};
+
+    std::string person_json = JS::serializeStruct(person);
+    std::cout << person_json << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
Files required for creating a conan package.
Fairly standard recipe for header only library.
Test package also included to make sure that the package can be properly consumed.
Project was not versioned, but conan requires versioning. Version set to 1.0.0 but this was arbitrary and project maintainer can modify.
Project is also missing a license, this was arbitrarily set to MIT, but project maintainer can modify.
